### PR TITLE
選択リストコンポーネントが文字が収まらない時は...で省力するように

### DIFF
--- a/src/components/atoms/select.tsx
+++ b/src/components/atoms/select.tsx
@@ -75,7 +75,21 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] max-w-[calc(100vw-2rem)] origin-[--radix-select-content-transform-origin] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        // Layout and positioning
+        'relative z-50 origin-[--radix-select-content-transform-origin]',
+        // Sizing
+        'max-h-[--radix-select-content-available-height] min-w-[8rem] max-w-[calc(100vw-2rem)]',
+        // Overflow and border
+        'overflow-y-auto overflow-x-hidden rounded-md border',
+        // Background and text
+        'bg-popover text-popover-foreground shadow-md',
+        // Animation states
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        // Slide-in transitions
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,

--- a/src/components/atoms/select.tsx
+++ b/src/components/atoms/select.tsx
@@ -19,16 +19,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground overflow-hidden',
+      'flex h-9 w-full items-center justify-between overflow-hidden rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground',
       className,
     )}
     {...props}
   >
-    <div className="truncate flex-1 text-left">
-      {children}
-    </div>
+    <div className="flex-1 truncate text-left">{children}</div>
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50 flex-shrink-0 ml-2" />
+      <ChevronDown className="ml-2 h-4 w-4 flex-shrink-0 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -131,7 +129,7 @@ const SelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
     <SelectPrimitive.ItemText asChild>
-      <span className="block truncate overflow-hidden text-ellipsis whitespace-nowrap pr-2">
+      <span className="block overflow-hidden truncate text-ellipsis whitespace-nowrap pr-2">
         {children}
       </span>
     </SelectPrimitive.ItemText>

--- a/src/components/atoms/select.tsx
+++ b/src/components/atoms/select.tsx
@@ -129,7 +129,7 @@ const SelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
     <SelectPrimitive.ItemText asChild>
-      <span className="block overflow-hidden truncate text-ellipsis whitespace-nowrap pr-2">
+      <span className="block truncate pr-2">
         {children}
       </span>
     </SelectPrimitive.ItemText>

--- a/src/components/atoms/select.tsx
+++ b/src/components/atoms/select.tsx
@@ -19,14 +19,16 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground [&>span]:line-clamp-1',
+      'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground overflow-hidden',
       className,
     )}
     {...props}
   >
-    {children}
+    <div className="truncate flex-1 text-left">
+      {children}
+    </div>
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 opacity-50 flex-shrink-0 ml-2" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -75,7 +77,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] origin-[--radix-select-content-transform-origin] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] max-w-[calc(100vw-2rem)] origin-[--radix-select-content-transform-origin] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,
@@ -128,7 +130,11 @@ const SelectItem = React.forwardRef<
         <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemText asChild>
+      <span className="block truncate overflow-hidden text-ellipsis whitespace-nowrap pr-2">
+        {children}
+      </span>
+    </SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/src/components/atoms/select.tsx
+++ b/src/components/atoms/select.tsx
@@ -129,9 +129,7 @@ const SelectItem = React.forwardRef<
       </SelectPrimitive.ItemIndicator>
     </span>
     <SelectPrimitive.ItemText asChild>
-      <span className="block truncate pr-2">
-        {children}
-      </span>
+      <span className="block truncate pr-2">{children}</span>
     </SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ));

--- a/src/components/molecules/CurrencySelect.tsx
+++ b/src/components/molecules/CurrencySelect.tsx
@@ -58,12 +58,16 @@ export function CurrencySelect({
 
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger>
+      <SelectTrigger className="w-full">
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
         {availableCurrencies.map((currency) => (
-          <SelectItem key={currency.code} value={currency.code}>
+          <SelectItem 
+            key={currency.code} 
+            value={currency.code}
+            title={`${currency.code} - ${currency.description}`}
+          >
             {currency.code} - {currency.description}
           </SelectItem>
         ))}

--- a/src/components/molecules/CurrencySelect.tsx
+++ b/src/components/molecules/CurrencySelect.tsx
@@ -64,7 +64,10 @@ export function CurrencySelect({
       </SelectTrigger>
       <SelectContent>
         {availableCurrencies.map((currency) => {
-          const displayText = formatCurrencyOption(currency.code, currency.description);
+          const displayText = formatCurrencyOption(
+            currency.code,
+            currency.description,
+          );
           return (
             <SelectItem
               key={currency.code}

--- a/src/components/molecules/CurrencySelect.tsx
+++ b/src/components/molecules/CurrencySelect.tsx
@@ -63,8 +63,8 @@ export function CurrencySelect({
       </SelectTrigger>
       <SelectContent>
         {availableCurrencies.map((currency) => (
-          <SelectItem 
-            key={currency.code} 
+          <SelectItem
+            key={currency.code}
             value={currency.code}
             title={`${currency.code} - ${currency.description}`}
           >

--- a/src/components/molecules/CurrencySelect.tsx
+++ b/src/components/molecules/CurrencySelect.tsx
@@ -7,6 +7,7 @@ import {
   SelectValue,
 } from '../atoms/select';
 import { CURRENCIES } from '@/lib/constants';
+import { formatCurrencyOption } from '@/lib/utils';
 import { Currency, CurrencySymbol } from '@/types';
 
 interface CurrencySelectProps {
@@ -62,15 +63,18 @@ export function CurrencySelect({
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
-        {availableCurrencies.map((currency) => (
-          <SelectItem
-            key={currency.code}
-            value={currency.code}
-            title={`${currency.code} - ${currency.description}`}
-          >
-            {currency.code} - {currency.description}
-          </SelectItem>
-        ))}
+        {availableCurrencies.map((currency) => {
+          const displayText = formatCurrencyOption(currency.code, currency.description);
+          return (
+            <SelectItem
+              key={currency.code}
+              value={currency.code}
+              title={displayText}
+            >
+              {displayText}
+            </SelectItem>
+          );
+        })}
       </SelectContent>
     </Select>
   );

--- a/src/components/molecules/CurrencySelectApi.tsx
+++ b/src/components/molecules/CurrencySelectApi.tsx
@@ -50,12 +50,16 @@ export function CurrencySelectApi({
 
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger>
+      <SelectTrigger className="w-full">
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
         {currencies.map((currency) => (
-          <SelectItem key={currency.code} value={currency.code}>
+          <SelectItem 
+            key={currency.code} 
+            value={currency.code}
+            title={`${currency.code} - ${currency.description}`}
+          >
             {currency.code} - {currency.description}
           </SelectItem>
         ))}

--- a/src/components/molecules/CurrencySelectApi.tsx
+++ b/src/components/molecules/CurrencySelectApi.tsx
@@ -55,8 +55,8 @@ export function CurrencySelectApi({
       </SelectTrigger>
       <SelectContent>
         {currencies.map((currency) => (
-          <SelectItem 
-            key={currency.code} 
+          <SelectItem
+            key={currency.code}
             value={currency.code}
             title={`${currency.code} - ${currency.description}`}
           >

--- a/src/components/molecules/CurrencySelectApi.tsx
+++ b/src/components/molecules/CurrencySelectApi.tsx
@@ -56,7 +56,10 @@ export function CurrencySelectApi({
       </SelectTrigger>
       <SelectContent>
         {currencies.map((currency) => {
-          const displayText = formatCurrencyOption(currency.code, currency.description);
+          const displayText = formatCurrencyOption(
+            currency.code,
+            currency.description,
+          );
           return (
             <SelectItem
               key={currency.code}

--- a/src/components/molecules/CurrencySelectApi.tsx
+++ b/src/components/molecules/CurrencySelectApi.tsx
@@ -6,6 +6,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../atoms/select';
+import { formatCurrencyOption } from '@/lib/utils';
 import { CurrencySymbol } from '@/types';
 
 interface CurrencySelectApiProps {
@@ -54,15 +55,18 @@ export function CurrencySelectApi({
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
-        {currencies.map((currency) => (
-          <SelectItem
-            key={currency.code}
-            value={currency.code}
-            title={`${currency.code} - ${currency.description}`}
-          >
-            {currency.code} - {currency.description}
-          </SelectItem>
-        ))}
+        {currencies.map((currency) => {
+          const displayText = formatCurrencyOption(currency.code, currency.description);
+          return (
+            <SelectItem
+              key={currency.code}
+              value={currency.code}
+              title={displayText}
+            >
+              {displayText}
+            </SelectItem>
+          );
+        })}
       </SelectContent>
     </Select>
   );

--- a/src/components/molecules/ParticipantSelect.tsx
+++ b/src/components/molecules/ParticipantSelect.tsx
@@ -31,8 +31,8 @@ export function ParticipantSelect({
       </SelectTrigger>
       <SelectContent>
         {participants.map((participant) => (
-          <SelectItem 
-            key={participant.id} 
+          <SelectItem
+            key={participant.id}
             value={participant.id}
             title={participant.name}
           >

--- a/src/components/molecules/ParticipantSelect.tsx
+++ b/src/components/molecules/ParticipantSelect.tsx
@@ -26,12 +26,16 @@ export function ParticipantSelect({
 }: ParticipantSelectProps) {
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger>
+      <SelectTrigger className="w-full">
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
         {participants.map((participant) => (
-          <SelectItem key={participant.id} value={participant.id}>
+          <SelectItem 
+            key={participant.id} 
+            value={participant.id}
+            title={participant.name}
+          >
             {participant.name}
           </SelectItem>
         ))}

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -144,7 +144,9 @@ describe('utils', () => {
   describe('formatCurrencyOption', () => {
     it('should format currency code and description correctly', () => {
       expect(formatCurrencyOption('USD', 'US Dollar')).toBe('USD - US Dollar');
-      expect(formatCurrencyOption('JPY', 'Japanese Yen')).toBe('JPY - Japanese Yen');
+      expect(formatCurrencyOption('JPY', 'Japanese Yen')).toBe(
+        'JPY - Japanese Yen',
+      );
       expect(formatCurrencyOption('EUR', 'Euro')).toBe('EUR - Euro');
     });
 
@@ -153,7 +155,9 @@ describe('utils', () => {
     });
 
     it('should handle special characters in description', () => {
-      expect(formatCurrencyOption('USD', 'United States Dollar (USD)')).toBe('USD - United States Dollar (USD)');
+      expect(formatCurrencyOption('USD', 'United States Dollar (USD)')).toBe(
+        'USD - United States Dollar (USD)',
+      );
     });
   });
 });

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -4,9 +4,9 @@ import {
   getInitials,
   formatCurrencyAmount,
   getCurrencyDisplayFormat,
-  isValidString,
-  isValidNumber,
+  formatCurrencyOption,
 } from '../utils';
+import { isValidString, isValidNumberIncludingZero } from '../schemas';
 import { CURRENCIES } from '../constants';
 
 describe('utils', () => {
@@ -125,19 +125,35 @@ describe('utils', () => {
     });
   });
 
-  describe('isValidNumber', () => {
+  describe('isValidNumberIncludingZero', () => {
     it('should return true for valid numbers', () => {
-      expect(isValidNumber(100)).toBe(true);
-      expect(isValidNumber(0)).toBe(true);
-      expect(isValidNumber('100')).toBe(true);
-      expect(isValidNumber('0')).toBe(true);
+      expect(isValidNumberIncludingZero(100)).toBe(true);
+      expect(isValidNumberIncludingZero(0)).toBe(true);
+      expect(isValidNumberIncludingZero('100')).toBe(true);
+      expect(isValidNumberIncludingZero('0')).toBe(true);
     });
 
     it('should return false for invalid numbers', () => {
-      expect(isValidNumber(-1)).toBe(false);
-      expect(isValidNumber('')).toBe(false);
-      expect(isValidNumber('abc')).toBe(false);
-      expect(isValidNumber(NaN)).toBe(false);
+      expect(isValidNumberIncludingZero(-1)).toBe(false);
+      expect(isValidNumberIncludingZero('')).toBe(false);
+      expect(isValidNumberIncludingZero('abc')).toBe(false);
+      expect(isValidNumberIncludingZero(NaN)).toBe(false);
+    });
+  });
+
+  describe('formatCurrencyOption', () => {
+    it('should format currency code and description correctly', () => {
+      expect(formatCurrencyOption('USD', 'US Dollar')).toBe('USD - US Dollar');
+      expect(formatCurrencyOption('JPY', 'Japanese Yen')).toBe('JPY - Japanese Yen');
+      expect(formatCurrencyOption('EUR', 'Euro')).toBe('EUR - Euro');
+    });
+
+    it('should handle empty description', () => {
+      expect(formatCurrencyOption('USD', '')).toBe('USD - ');
+    });
+
+    it('should handle special characters in description', () => {
+      expect(formatCurrencyOption('USD', 'United States Dollar (USD)')).toBe('USD - United States Dollar (USD)');
     });
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -128,6 +128,9 @@ export function calculateBasicTotalAmount(
 /**
  * 通貨選択肢の表示フォーマットを生成する関数
  */
-export function formatCurrencyOption(code: string, description: string): string {
+export function formatCurrencyOption(
+  code: string,
+  description: string,
+): string {
   return `${code} - ${description}`;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -125,10 +125,9 @@ export function calculateBasicTotalAmount(
   return expenses.reduce((sum, expense) => sum + expense.amount, 0);
 }
 
-// ...existing code...
-
-// バリデーション関数は schemas.ts から再エクスポート
-export {
-  isValidString,
-  isValidNumberIncludingZero as isValidNumber,
-} from './schemas';
+/**
+ * 通貨選択肢の表示フォーマットを生成する関数
+ */
+export function formatCurrencyOption(code: string, description: string): string {
+  return `${code} - ${description}`;
+}


### PR DESCRIPTION
### 概要
選択リストコンポーネント内の文字を省略表記可能にすることで、親の横幅を超えて中身を表示しないようにしました。

---
### 関連issue (あれば)
Closes #4 

---
## 👀 レビュー観点 (AI向け)
**レビューを行う際は、まず以下の共通観点チェックリストを確認してください。**
**レビューは全て日本語で行なってください。** ➡️ **[共通レビュー観点チェックリスト](./REVIEW_PERSPECTIVES.md)**

---
### 確認事項
- [ ] ローカルで動作確認した
- [ ] Linterのエラーがない
- [ ] 不要な `console.log` は削除した
- [ ] 実装した機能のテストは追加したか？

---
## 備考 (Notes)
