### PR TITLE
精算ボタンの表示場所を画面幅に合わせて配置するように

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,3 @@
-# 指示
-あなたは、GitHub Copilotのエキスパートです。これから開発する新機能について、タスクをステップごとに分割し、具体的な実装をサポートしてください。
-
 # コンテキスト
 現在、「旅行費用割り勘精算アプリケーション」を開発しています。
 **目的:** アプリケーション内で通貨換算機能を追加し、ユーザーが複数の通貨で支払った費用を任意の通貨で精算できるようにすること。
@@ -14,8 +11,8 @@
 以下のAPIを利用して、通貨に関する機能を実装してください。
 **APIドキュメント:** https://exchangerate.host/documentation
 **エンドポイント:**
-- 通貨リストの取得: `https://api.exchangerate.host/symbols`
-- 為替レートの取得: `https://api.exchangerate.host/latest`
+- 通貨リストの取得: `https://api.exchangerate.host/list`
+- 為替レートの取得: `https://api.exchangerate.host/live`
 
 # タスク詳細
 1. **アーキテクチャの定義:**

--- a/IMPLEMENTATION_REPORT.md
+++ b/IMPLEMENTATION_REPORT.md
@@ -1,4 +1,4 @@
-# 通貨換算機能実装完了レポート
+# 通貨換算機能実装
 
 ## 🎯 実装概要
 
@@ -19,8 +19,8 @@ ARCHITECTURE.mdに従い、旅行費用割り勘精算アプリケーション�
 ## 🔧 実装した機能
 
 ### 1. 通貨情報取得
-- `https://api.exchangerate.host/symbols` から利用可能通貨リストを取得
-- `https://api.exchangerate.host/latest` から最新為替レートを取得
+- `https://api.exchangerate.host/list` から利用可能通貨リストを取得
+- `https://api.exchangerate.host/live` から最新為替レートを取得
 
 ### 2. 通貨変換
 - 異なる通貨間での金額変換
@@ -141,10 +141,10 @@ const result = await settlementUseCase.calculateSettlementsWithCurrency(
 
 ### UI層
 - `src/components/molecules/CurrencySelectApi.tsx`
-- `src/components/organisms/SettlementSection.tsx` (更新)
+- `src/components/organisms/SettlementSection.tsx`
 - `src/hooks/useCurrency.ts`
 
 ### 型定義
-- `src/types/index.ts` (拡張)
+- `src/types/index.ts`
 
 この実装により、プロジェクトの設計思想である「シンプルさと表現力」「型安全性の徹底」「開発者体験と所有権」を満たした、保守性と拡張性の高い通貨換算機能が完成しました。

--- a/src/components/organisms/SettlementSection.tsx
+++ b/src/components/organisms/SettlementSection.tsx
@@ -107,8 +107,8 @@ export function SettlementSection({
             >
               精算通貨
             </label>
-            <div className="flex space-x-2">
-              <div className="flex-1">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+              <div className="min-w-0 flex-1">
                 <CurrencySelectApi
                   value={selectedCurrency}
                   onValueChange={setSelectedCurrency}
@@ -124,7 +124,7 @@ export function SettlementSection({
                   participants.length === 0 ||
                   expenses.length === 0
                 }
-                className="whitespace-nowrap"
+                className="shrink-0 whitespace-nowrap"
               >
                 {isCalculating ? '計算中...' : '精算計算'}
               </Button>


### PR DESCRIPTION
### 概要
精算結果セクションの通貨選択と精算計算のボタンが並んでいる箇所において、通貨のテキストが長い場合、ボタンが枠から右にはみ出してしまう問題を解決

---
### 関連issue (あれば)
Closes #6

---
## 👀 レビュー観点 (AI向け)
**レビューを行う際は、まず以下の共通観点チェックリストを確認してください。**
**レビューは全て日本語で行なってください。** ➡️ **[共通レビュー観点チェックリスト](./REVIEW_PERSPECTIVES.md)**

---
### 確認事項
- [ ] ローカルで動作確認した
- [ ] Linterのエラーがない
- [ ] 不要な `console.log` は削除した
- [ ] 実装した機能のテストは追加したか？

---
## 備考 (Notes)
